### PR TITLE
GenMod Patch

### DIFF
--- a/src/biolockj/util/BashScriptBuilder.java
+++ b/src/biolockj/util/BashScriptBuilder.java
@@ -246,6 +246,7 @@ public class BashScriptBuilder {
 			lines.add( TEMP_DIR + "=\"" + module.getTempDir().getAbsolutePath() + "\"" );
 		lines.add( "" );
 		lines.add( "touch \"" + scriptPath + "_" + Constants.SCRIPT_STARTED  + "\"" + RETURN );
+		lines.add( "cd " + module.getScriptDir().getAbsolutePath() + RETURN );
 		lines.addAll( loadModules( module ) );
 
 		final List<String> workerFunctions = module.getWorkerScriptFunctions();


### PR DESCRIPTION
Worker scripts should set the working directory to the module script dir, just like MAIN does. This is necessary when the worker script is launched using a mechanism (ex qsub) that does not preserve the current working directory. Not all processes are affected by the working dir, but some may be (ex GenMod is).