### PR TITLE
The launch_java script should be able to tell the user if the pipelin…

### DIFF
--- a/script/blj_user_arg_lib
+++ b/script/blj_user_arg_lib
@@ -28,13 +28,14 @@ set_arg_names(){
 	EXT_MODS_ARG="external-modules"
 	BLJ_ARG="blj"
 	BLJ_SUP_ARG="blj_sup"
+	WAIT_ARG="wait-for-start"
 }
 
 init_defaults(){
 	# Order does not matter for $longArgName or $takeShortArg, but it is easier to read if they match
 	# Order MATTERS for $shortArgName and $parameters ---they must match whatever order is in $longArgName.
-	longArgName=( $GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $EXT_MODS_ARG $BLJ_ARG $BLJ_SUP_ARG )
-	takeShortArg=($GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG help version)
+	longArgName=( $GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $WAIT_ARG $EXT_MODS_ARG $BLJ_ARG $BLJ_SUP_ARG )
+	takeShortArg=($GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $WAIT_ARG help version)
 	shortArgName=()
 	parameters=()
 	mustTakeValue=($PASSWORD_ARG $CONFIG_ARG $EXT_MODS_ARG)
@@ -131,7 +132,10 @@ assign_main_arg(){
 	if ifArgUsed $RESTART_ARG ; then
 		restartDir=$mainArg
 		[ ${#BIOLOCKJ_TEST_MODE} -gt 0 ] && echo "Using $restartDir as the pipeline to restart."
-		ifArgUsed $CONFIG_ARG && configFile=configoverride && echo "Updating pipeline with config file $configFile."
+		if ifArgUsed $CONFIG_ARG ; then
+			configFile=$(get_arg_value $CONFIG_ARG)
+			echo "Updating pipeline with config file $configFile."
+		fi
 	else
 		configFile=$mainArg
 		[ ${#BIOLOCKJ_TEST_MODE} -gt 0 ] && echo "Using $configFile as the config file."
@@ -239,6 +243,7 @@ display_help() {
     addSpace "$AWS_ARG"      "Run on aws"
     addSpace "$GUI_ARG"      "Start the BioLockJ GUI"
     addSpace "$FG_ARG"       "Run the java process in the foreground without nohup"
+    addSpace "$WAIT_ARG"     "Do not release terminal until pipeline completes check-dependencies step."
     addSpace "$EXT_MODS_ARG <dir>" "Directory with compiled java code giving additional modules"
     addSpace "$BLJ_ARG"      "Map \$BLJ folder into the docker container;"
     continueDescriptoin      "this replaces BioLockJ packaged in a docker container with the local copy."

--- a/script/launch_java
+++ b/script/launch_java
@@ -90,25 +90,89 @@ after_java_start(){
 
 confirm_java_started(){
 	[ $? != 0 ] && exit_with_message "Error [ biolockj ]:  Unable to run ${BLJ_JAR}"
-	printf "Initializing BioLockJ."
+	printf "Initializing BioLockJ"
 	i=0
-	while [ $i -lt 15 ] && [ "${initDir}" == "${pipeDir}" ] && [ ${initJava} -eq ${numJava} ]; do
-		sleep 3 && i=$((i+1)) && printf "." && pipeDir="$(most_recent_pipeline)" && numJava=$(ps | grep -c java)
+	maxtime=15
+	while [ $i -lt $maxtime ] || ifArgUsed $WAIT_ARG && [ "${initDir}" == "${pipeDir}" ] && [ ${initJava} -eq ${numJava} ]; do
+		printf "."
+		sleep 1
+		i=$((i+1))
+		pipeDir="$(most_recent_pipeline)"
+		numJava=$(ps | grep -c java)
+		if [ $i -eq 10 ]; then
+			printf "waiting for java to start"
+		fi
+		if [ $i -eq $maxtime ]; then
+			if ifArgUsed $WAIT_ARG ; then
+				echo "The normal timeout has been disabled."
+			else
+				echo "Reached max wait time: $maxtime seconds."
+			fi
+		fi
 	done
-	sleep 1 && echo "." && pipeDir="$(most_recent_pipeline)"
+	sleep 1
+	echo "."
+	pipeDir="$(most_recent_pipeline)" # could lag slightly after java start
 }
 
 print_info(){
-	if [ ${#restart} -gt 0 ] && [ ${numJava} -gt ${initJava} ]; then 
+	if ifArgUsed $RESTART_ARG && [ ${numJava} -gt ${initJava} ]; then 
 		echo "Restarting pipeline:  ${pipeDir}"
-	elif [ ${#restart} -eq 0 ] && [ "${initDir}" != "${pipeDir}" ] || [ ${numJava} -gt ${initJava} ]; then 
-		echo "Starting pipeline:  ${pipeDir}"
-	elif [ ${#restart} -eq 0 ] && [ ${#runGui} -eq 0 ]; then
+		print_action_options
+		print_status
+	elif [ "${initDir}" != "${pipeDir}" ] ; then 
+		echo "Building pipeline:  ${pipeDir}"
+		print_action_options
+		print_status
+	elif ! ifArgUsed $RESTART_ARG && ! ifArgUsed $GUI_ARG; then
 		echo "Pipeline may have failed to launch - check $BLJ_PROJ for new pipeline"
+		print_action_options
 	fi
+}
+
+
+print_action_options(){
 	echo "blj_go       -> Move to pipeline output directory"
 	echo "blj_log      -> Tail pipeline log (accepts tail runtime parameters)"
 	echo "blj_summary  -> View module execution summary"
+}
+
+print_status(){
+	printf "Fetching pipeline status "
+	i=0
+	while [ $i -lt 5 ] || ifArgUsed $WAIT_ARG ; do
+		if [ -f ${pipeDir}/biolockjFailed ]; then 
+			echo ""; echo ""
+			echo "BioLockJ has stopped."
+			echo ""
+			cat ${pipeDir}/biolockjFailed
+			echo ""; echo ""
+			exit
+		elif [ -f ${pipeDir}/biolockjComplete ]; then
+			echo ""; echo ""
+			echo "Pipeline is complete."
+			exit
+		elif ! ifArgUsed $RESTART_ARG && [ -f ${pipeDir}/00_*/biolockj* ]; then
+			echo ""; echo ""
+			echo "Pipeline is running."
+			exit
+		elif ifArgUsed $RESTART_ARG && [ $i -gt 3 ] && [ -f ${pipeDir}/*/biolockjStarted ]; then #TODO need better indicator
+			completeMods=(${pipeDir}/*/biolockjComplete)
+			numComplete=${#completeMods[@]}
+			echo ""; echo ""
+			echo "Pipeline is running, with $numComplete modules completed."
+			exit
+		elif [ $i -eq 1 ]; then
+			ifArgUsed $WAIT_ARG && printf "(no timeout) "
+		elif [ $i -gt 1 ]; then
+			printf "."
+		fi
+		sleep 1
+		i=$((i+1))
+	done
+	echo ""
+	echo "Could not verify that the pipeline is running."
+	echo "It may still be checking dependencies."
 }
 
 main $@

--- a/src/biolockj/exception/FatalExceptionHandler.java
+++ b/src/biolockj/exception/FatalExceptionHandler.java
@@ -43,7 +43,7 @@ public class FatalExceptionHandler {
 		System.out.println( ERROR_MSG + ex.getMessage() );
 		if( Log.getFile() != null && Log.getFile().isFile() ) {
 			setErrorLog( Log.getFile() );
-			setFailedStatus();
+			setFailedStatus(ex);
 			SummaryUtil.addSummaryFooterForFailedPipeline();
 		} else setErrorLog( createErrorLog() );
 
@@ -152,10 +152,18 @@ public class FatalExceptionHandler {
 		errorLog = file;
 	}
 
-	private static void setFailedStatus() {
+	private static void setFailedStatus(Exception fetalEx) {
 		try {
-			if( Config.getPipelineDir() != null )
-				BioLockJUtil.createFile( Config.pipelinePath() + File.separator + Constants.BLJ_FAILED );
+			if( Config.getPipelineDir() != null ) {
+				String failFlagPath = Config.pipelinePath() + File.separator + Constants.BLJ_FAILED;
+				BioLockJUtil.createFile( failFlagPath );
+				if( fetalEx != null ) {
+					final FileWriter writer = new FileWriter( new File( failFlagPath ) );
+					writer.write( ERROR_TYPE + fetalEx.getClass().getSimpleName() + System.lineSeparator() );
+					writer.write( ERROR_MSG + fetalEx.getMessage() );
+					writer.close();
+				}
+			}
 		} catch( final Exception ex ) {
 			Log.error( FatalExceptionHandler.class,
 				"Pipeline root directory not found - unable save Pipeline Status File: " + Constants.BLJ_FAILED +
@@ -165,6 +173,6 @@ public class FatalExceptionHandler {
 
 	private static File errorLog = null;
 	private static final String FATAL_ERROR_FILE_PREFIX = "BioLockJ_FATAL_ERROR_";
-	public static final String ERROR_TYPE = "ERROR TYPE: ";
-	public static final String ERROR_MSG = "ERROR MESSAGE: ";
+	public static final String ERROR_TYPE = "ERROR TYPE:    ";
+	public static final String ERROR_MSG =  "ERROR MESSAGE: ";
 }


### PR DESCRIPTION
…e failed in check-dependencies

 * or if the pipeline progressed to start running modules.
 * Add the wait arg option, support it in launch_java, and improve messages for reporting pipeline status.
 * Use the same constants to give error type and error message when writing to the BioLockJ_Failed file.
 * bug fix in user arg lib