### PR TITLE
Implement the AS keyword to specify an alias for an instance of a module

### DIFF
--- a/mkdocs/user-guide/docs/Configuration.md
+++ b/mkdocs/user-guide/docs/Configuration.md
@@ -37,7 +37,7 @@ A copy of each configuration file is stored in the pipeline root directory to se
 
 ## BioModule execution order
 
-To include a BioModule in your pipeline, add a `#BioModule` line to the top your configuration file, as shown in the examples found in [templates]( https://github.com/msioda/BioLockJ/tree/master/resources/config/template ).  Each line has the `#BioModule` keyword followed by the path to the jar file for that module.  For example:
+To include a BioModule in your pipeline, add a `#BioModule` line to the top your configuration file, as shown in the examples found in [templates]( https://github.com/msioda/BioLockJ/tree/master/resources/config/template ).  Each line has the `#BioModule` keyword followed by the path for that module.  For example:
 
 ```
 #BioModule biolockj.module.seq.PearMergeReads
@@ -46,6 +46,14 @@ To include a BioModule in your pipeline, add a `#BioModule` line to the top your
 ```
 
 BioModules will be executed in the order they are listed in here.  A typical pipeline contians one [classifier module](../module/classifier/module.classifier).  Any number of [sequence pre-processing](../module/seq/module.seq) modules may come before the classifier module. Any number of [report modules](../module/report/module.report) may come after the classifier module.  In addition to the BioModules specified in the configuration file, BioLockJ may add [implicit modules](../module/implicit/module.implicit) that the are required by specified modules.  See [Example Pipeline](Example-Pipeline).
+
+A module can be given an alias by using the `AS` keyword in its execution line:
+```
+#BioModule biolockj.module.seq.PearMergeReads AS Pear
+```
+This is is generally used for modules that are used more than once in the same pipeline.  Given this alias, the folder for this module will be called `01_Pear` instead of `01_PearMergeReads`, and any general properties directed to this module would use the prefix `Pear` instead of `PearMergedReads`. An alias must start with a capital letter, and cannot duplicate a name/alias of any other module in the same pipeline.  
+
+Some pipeline properties (usually those used by pipeline utilities) can be directed to a specific module.  For example, `script.numThreads` is a general property that specifies that number of threads alloted to each script launched by any module; and `PearMergeReads.numThreads` overrides that property ONLY for the PearMergeReads module.  
 
 ## Summary of Properties
 

--- a/mkdocs/user-guide/docs/module/diy/module.diy.md
+++ b/mkdocs/user-guide/docs/module/diy/module.diy.md
@@ -1,17 +1,49 @@
 # Do It Yourself - DIY Package
 DIY package 
 ---
-The DIY package allows users to customize BioLockJ to fit their needs. 
+The DIY package allows users to customize BioLockJ. 
 #### GenMod
 `#BioModule biolockj.module.diy.GenMod`
 
-Description: Allows user to add external scripts into the BioLockJ pipeline.
+Description: Allows user to add their own scripts into the BioLockJ pipeline.
 
 **Options:**
 
    - *genMod.launcher* 
    - *genMod.param*
    - *genMod.scriptPath*
+   - *genMod.dockerContainerName*
 
+
+The specified script is executed using the modules script directory as the current working directory. A _scriptPath_ is required.  If specified, the _launcher_ program (ie R, Python) will be used.  If specified, any _param_ will be listed as arguments to the script.  If running in docker, _dockerContainerName_ is required.
+
+This is ideal for:
+
+ * Custom analysis for a given pipeline, such as an R or python script
+ * Any steps where an appropriate BioLockJ module does not exist
+
+Any step in your analysis process that might otherwise have to be done manually can be stored as a custom script so that the entire process is as reproducible as possible.
+
+It is SCRONGLY encouraged that users write scripts using common module conventions:
+
+ * use relative file paths (starting with `.` or `..`)
+ * put all generated output in the modules `output` directory (`../output`)
+ * put any temporary files in the modules `temp` directory (`../tmep`).  
+ * the main pipeline directory would be `../..`, and the output of a previous module such as `PearMergedReads` would be in `../../*_PearMergedReads/output`
+
+To use the GenMod module multiple times in a single pipeline, use the `AS` keyword to direct properties to the correct instance of the module.
+
+For example:
+```
+#BioModule biolockj.module.diy.GenMod AS Part1
+#<other modules>
+#BioModule biolockj.module.diy.GenMod AS Part2
+
+Part1.launcher=python
+Part1.script=path/to/first/script.py
+
+Part2.script=path/to/bash/script/doLast.sh
+```
+With this, `script.py` will be run using python.  Then other modules will run. Then `doLast.sh` will be run using the default system (probably bash, unless it has a shebang line specifiying something else).
 
 ---

--- a/resources/config/default/standard.properties
+++ b/resources/config/default/standard.properties
@@ -61,6 +61,11 @@ exe.krakenParams=--only-classified-output, --preload
 #exe.vsearch=
 #exe.vsearchParams=
 ##################################################################
+#genMod.dockerContainerName
+#genMod.launcher
+#genMod.param
+#genMod.scriptPath
+##################################################################
 #humann2.disablePathAbundance=
 #humann2.disablePathCoverage=
 #humann2.disableGeneFamilies=

--- a/src/biolockj/Constants.java
+++ b/src/biolockj/Constants.java
@@ -20,6 +20,11 @@ public class Constants {
 	 * Captures the application start time
 	 */
 	public static final long APP_START_TIME = System.currentTimeMillis();
+	
+	/**
+	 * The key string to define an alias for an individual module: {@value 
+	 */
+	public static final String ASSIGN_ALIAS = " AS ";
 
 	/**
 	 * {@link biolockj.Config} Integer property: {@value #AWS_S3_XFER_TIMEOUT}<br>

--- a/src/biolockj/Pipeline.java
+++ b/src/biolockj/Pipeline.java
@@ -19,7 +19,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import biolockj.exception.DirectModuleException;
-import biolockj.exception.FatalExceptionHandler;
 import biolockj.module.*;
 import biolockj.module.report.Email;
 import biolockj.module.report.r.R_Module;
@@ -95,8 +94,6 @@ public class Pipeline {
 		Log.info( Pipeline.class, "Initialize " + ( BioLockJUtil.isDirectMode() ? "DIRECT module ":
 			DockerUtil.inAwsEnv() ? "AWS ": DockerUtil.inDockerEnv() ? "DOCKER ": "" ) + "pipeline" );
 		bioModules = BioModuleFactory.buildPipeline();
-		if( !BioLockJUtil.isDirectMode() )
-			Config.setConfigProperty( Constants.INTERNAL_ALL_MODULES, BioLockJUtil.getClassNames( bioModules ) );
 		initializeModules();
 	}
 

--- a/src/biolockj/Properties.java
+++ b/src/biolockj/Properties.java
@@ -187,7 +187,7 @@ public class Properties extends java.util.Properties {
 		try {
 			for( String line = reader.readLine(); line != null; line = reader.readLine() )
 				if( line.startsWith( Constants.BLJ_MODULE_TAG ) ) {
-					final String moduleName = line.trim().substring( line.indexOf( " " ) + 1 );
+					final String moduleName = line.replaceFirst( Constants.BLJ_MODULE_TAG, "" ).trim();
 					Log.info( Properties.class, "Configured BioModule: " + moduleName );
 					modules.add( moduleName );
 				}

--- a/src/biolockj/exception/PipelineFormationException.java
+++ b/src/biolockj/exception/PipelineFormationException.java
@@ -1,0 +1,30 @@
+package biolockj.exception;
+
+import java.util.List;
+import biolockj.Log;
+import biolockj.Pipeline;
+import biolockj.module.BioModule;
+import biolockj.util.BioLockJUtil;
+
+/**
+ * PipelineFormationException is thrown when there is a problem in setting up the modules to run.
+ * For example, if there is problem in reading the module run order, or initializing the pipeline.
+ * @author Ivory
+ *
+ */
+public class PipelineFormationException extends BioLockJException {
+
+	public PipelineFormationException( String msg ) {
+		super( msg );
+		List<BioModule> modules = Pipeline.getModules();
+		if ( modules != null && modules.size() > 0 ) {
+			Log.info(this.getClass(), "The modules defined thus far are: "
+				 + BioLockJUtil.getCollectionAsString( modules ));
+		}else {
+			Log.info(this.getClass(), "No modules have been added to the pipeline yet.");
+		}
+	}
+
+	private static final long serialVersionUID = -392199812676699152L;
+
+}

--- a/src/biolockj/exception/ValidationException.java
+++ b/src/biolockj/exception/ValidationException.java
@@ -42,7 +42,7 @@ public class ValidationException extends BioLockJException {
 
 	private static String buildMessage( final BioModule module ) {
 		return "This pipeline has validaiton turned on to verify the output of module " +
-			ModuleUtil.displayID( module ) + "_" + module.getClass().getSimpleName() +
+			ModuleUtil.displaySignature( module ) +
 			". The output is different from the expectations, so the pipeline was halted.";
 	}
 

--- a/src/biolockj/module/BioModule.java
+++ b/src/biolockj/module/BioModule.java
@@ -13,6 +13,7 @@ package biolockj.module;
 
 import java.io.File;
 import java.util.List;
+import biolockj.exception.PipelineFormationException;
 
 /**
  * Classes that implement this interface are eligible to be included in a BioLockJ pipeline.<br>
@@ -68,6 +69,17 @@ public interface BioModule {
 	 * @return Module ID
 	 */
 	public Integer getID();
+	
+	/**
+	 * Some BioModules may be added to a pipeline multiple times.<br>
+	 * The user may provide an alias for a module in the run order, 
+	 * thus allowing the user direct properties to an individual instance of a module.
+	 * 
+	 * @return Module ID
+	 */
+	public String getAlias(); 
+
+	public void setAlias( String alias ) throws PipelineFormationException; 
 
 	/**
 	 * Each BioModule takes the previous BioModule output as input:<br>

--- a/src/biolockj/module/BioModuleImpl.java
+++ b/src/biolockj/module/BioModuleImpl.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.filefilter.HiddenFileFilter;
 import biolockj.*;
 import biolockj.exception.ConfigFormatException;
 import biolockj.exception.ConfigNotFoundException;
+import biolockj.exception.PipelineFormationException;
 import biolockj.util.*;
 
 /**
@@ -67,6 +68,19 @@ public abstract class BioModuleImpl implements BioModule, Comparable<BioModule> 
 
 	@Override
 	public abstract void executeTask() throws Exception;
+	
+	@Override
+	public String getAlias() {
+		return alias;
+	}
+
+	@Override
+	// TODO: limit this access... maybe move BioModule and BioModuleImpl to the biolockj package
+	public void setAlias( String alias ) throws PipelineFormationException {
+		if (alias.contains( "." )) throw new PipelineFormationException( "Invalid alias: [" + alias + "]; an alias cannot contain a \".\" character." );
+		if ( ! alias.substring( 0, 1 ).equals( alias.substring( 0, 1 ).toUpperCase() )) throw new PipelineFormationException("Invalid alias: [" + alias + "]; an alias must start with a capital letter.");
+		this.alias = alias;
+	}
 
 	@Override
 	public Integer getID() {
@@ -155,7 +169,7 @@ public abstract class BioModuleImpl implements BioModule, Comparable<BioModule> 
 	public void init() throws Exception {
 		this.moduleId = nextId++;
 		this.moduleDir = new File(
-			Config.pipelinePath() + File.separator + ModuleUtil.displayID( this ) + "_" + getClass().getSimpleName() );
+			Config.pipelinePath() + File.separator + ModuleUtil.displaySignature( this ) );
 
 		if( !this.moduleDir.isDirectory() ) {
 			this.moduleDir.mkdirs();
@@ -184,7 +198,7 @@ public abstract class BioModuleImpl implements BioModule, Comparable<BioModule> 
 	public String toString() {
 		String val = getID() + "_" + getClass().getName();
 		try {
-			val = ModuleUtil.displayID( this ) + "_" + getClass().getName();
+			val = ModuleUtil.displaySignature( this );
 		} catch( final Exception ex ) {
 			Log.error( getClass(), "Unable to find ID for: " + getClass().getName(), ex );
 		}
@@ -281,6 +295,7 @@ public abstract class BioModuleImpl implements BioModule, Comparable<BioModule> 
 	private final List<File> inputFiles = new ArrayList<>();
 	private File moduleDir = null;
 	private Integer moduleId;
+	private String alias = null;
 
 	/**
 	 * BioLockJ gzip file extension constant: {@value #GZIP_EXT}

--- a/src/biolockj/util/MasterConfigUtil.java
+++ b/src/biolockj/util/MasterConfigUtil.java
@@ -126,7 +126,7 @@ public class MasterConfigUtil {
 				final String val = usedProps.get( key );
 				if( val == null || val.trim().isEmpty() ) Log.debug( MasterConfigUtil.class,
 					"Remove unused property from sanatized MASTER Config: " + key + "=" + val );
-				else if( !isInternalProperty(key) ) props.put( key, val );
+				else if( !Config.isInternalProperty(key) ) props.put( key, val );
 			}
 
 			Log.info( MasterConfigUtil.class, "The original version of project Config contained: " +
@@ -246,7 +246,7 @@ public class MasterConfigUtil {
 			final TreeSet<String> keys = new TreeSet<>( props.keySet() );
 			for( final String key: keys ) {
 				final String val = props.get( key );
-				if( isInternalProperty(key) && val != null && !val.isEmpty() )
+				if( Config.isInternalProperty(key) && val != null && !val.isEmpty() )
 					writer.write( "###     " + key + "=" + props.get( key ) + RETURN );
 			}
 			writer.write( "###" + RETURN );
@@ -271,10 +271,6 @@ public class MasterConfigUtil {
 		for( final String module: Config.getList( null, Constants.INTERNAL_BLJ_MODULE ) )
 			writer.write( Constants.BLJ_MODULE_TAG + " " + module + RETURN );
 		writer.write( RETURN );
-	}
-	
-	private static boolean isInternalProperty( final String property ) {
-		return property.startsWith( Constants.INTERNAL_PREFIX );
 	}
 
 	private static final String DEFAULT_CONFIG_FLAG = "# ----> Default Config: ";

--- a/src/biolockj/util/ModuleUtil.java
+++ b/src/biolockj/util/ModuleUtil.java
@@ -44,6 +44,22 @@ public class ModuleUtil {
 	public static String displayID( final BioModule module ) {
 		return BioLockJUtil.formatDigits( module.getID(), 2 );
 	}
+	
+	/**
+	 * Return the name of the module (or an alias if it has one).
+	 * 
+	 * @param module BioModule
+	 * @return ID display value
+	 */
+	public static String displayName( final BioModule module ) {
+		String alias = module.getAlias();
+		if (alias != null) return alias;
+		return module.getClass().getSimpleName();
+	}
+	
+	public static String displaySignature( final BioModule module ) {
+		return displayID( module ) + "_" + displayName( module );
+	}
 
 	/**
 	 * Get a classifier module<br>
@@ -140,13 +156,24 @@ public class ModuleUtil {
 	}
 
 	/**
-	 * Construct a BioModule based on its className.
+	 * Construct a BioModule based on its className for temporary use.
 	 * 
 	 * @param className BioModule class name
 	 * @return BioModule module
 	 * @throws Exception if errors occur
 	 */
-	public static BioModule getModule( final String className ) throws Exception {
+	public static BioModule getTempModule( final String className ) throws Exception {
+		return (BioModule) Class.forName( className ).newInstance();
+	}
+	
+	/**
+	 * Construct a BioModule based on its className to add it to the pipeline.
+	 * 
+	 * @param className BioModule class name
+	 * @return BioModule module
+	 * @throws Exception if errors occur
+	 */
+	public static BioModule createModuleInstance( final String className ) throws Exception {
 		return (BioModule) Class.forName( className ).newInstance();
 	}
 
@@ -330,7 +357,7 @@ public class ModuleUtil {
 		BioLockJUtil.markStatus( module, Constants.BLJ_COMPLETE );
 		Log.info( ModuleUtil.class, Constants.LOG_SPACER );
 		Log.info( ModuleUtil.class,
-			"FINISHED [ " + ModuleUtil.displayID( module ) + " ] " + module.getClass().getName() );
+			"FINISHED [ " + ModuleUtil.displaySignature( module ) + " ] " );
 		Log.info( ModuleUtil.class, Constants.LOG_SPACER );
 	}
 
@@ -348,7 +375,7 @@ public class ModuleUtil {
 		BioLockJUtil.markStatus( module, Constants.BLJ_STARTED );
 		Log.info( ModuleUtil.class, Constants.LOG_SPACER );
 		Log.info( ModuleUtil.class,
-			"STARTING [ " + ModuleUtil.displayID( module ) + " ] " + module.getClass().getName() );
+			"STARTING [ " + ModuleUtil.displaySignature( module ) + " ] " );
 		Log.info( ModuleUtil.class, Constants.LOG_SPACER );
 	}
 

--- a/src/biolockj/util/ValidationUtil.java
+++ b/src/biolockj/util/ValidationUtil.java
@@ -269,7 +269,7 @@ public class ValidationUtil {
 					if( canHaltPipeline( module ) ) throw new ValidationException( module );
 				}
 			} else Log.debug( ValidationUtil.class, "Validation is turned off for module: " +
-				ModuleUtil.displayID( module ) + "_" + module.getClass().getSimpleName() );
+				ModuleUtil.displaySignature( module ) );
 		} catch( final BioLockJException bljEx ) {
 			throw bljEx;
 		} catch( final Exception ex ) {
@@ -376,7 +376,7 @@ public class ValidationUtil {
 	}
 
 	private static String getOutputFileName( final BioModule module ) {
-		return ModuleUtil.displayID( module ) + "_" + module.getClass().getSimpleName() + OUTPUT_FILE_SUFFIX;
+		return ModuleUtil.displaySignature( module ) + OUTPUT_FILE_SUFFIX;
 	}
 
 	private static HashMap<String, FileSummary> getPrevSummaries( final BioModule module ) throws BioLockJException {
@@ -400,8 +400,7 @@ public class ValidationUtil {
 
 			rowNum++;
 		}
-		if( prevOutput.isEmpty() ) Log.info( ValidationUtil.class, "Module " + ModuleUtil.displayID( module ) + "_" +
-			module.getClass().getSimpleName() + " is expected to have not output." );
+		if( prevOutput.isEmpty() ) Log.info( ValidationUtil.class, "Module " + ModuleUtil.displaySignature( module ) + " is expected to have no output." );
 		return prevOutput;
 	}
 


### PR DESCRIPTION
 * if a module has an alias, use the alias for form the folder name
 * if a moudle has an alias, use the alias for module-specific property form
 * do not allow duplicated name/alias in the same pipeline
 * as a convention, property names are lowercase, while name/alias start with upper case
 * consolidate all the times that we create '02_ModuleName' into a method: displaySignature
 * consolidate all the tiems we get a modules getSimpleName to instead use displayName, and use the alias if it has one.