### PR TITLE
Add 'precheck' option.

### DIFF
--- a/mkdocs/user-guide/docs/Check-Dependencies.md
+++ b/mkdocs/user-guide/docs/Check-Dependencies.md
@@ -1,0 +1,13 @@
+
+BioLockJ is designed find all problems in one sitting.  Every module includes a _check dependencies_ method, which quickly detects issues that would cause an error during execution.  This is run for all modules in a pipeline _before_ the first module executes.  
+
+When BioLockJ runs, it has three major phases:      
+
+ * pipeline formation - string together the modues specified in the config file along with any additional modules that the program adds on the users behalf; and initiate the utilities needed for the pipeline (such as docker, metadata, determine input type).
+ * check dependencies - scan the pipeline for anything that may cause an error during execution
+ * run pipeline - execute each module in the sequence.
+
+
+## Precheck a pipeline
+
+By including the `--precheck-only` argument (or `-p`) when running `biolockj`; you are running in **precheck** mode.  BioLockJ will do the first two phases, and then stop.  This allows you to quickly test changes to your pipeline configuration without actually running a pipeline. It also allows you to see any modules that are automatically added to your pipeline.

--- a/mkdocs/user-guide/docs/Getting-Started.md
+++ b/mkdocs/user-guide/docs/Getting-Started.md
@@ -46,7 +46,21 @@ qstat -u $USER                                                                  
 
 ```
 
-### 5. Investigate Failed Pipelines
-* Failed pipelines can be restarted to save the progress made by successful modules.
-* See [Failure Recovery](../Failure-Recovery) for more information.
-* Failure Recovery should be avoided until you have successfully completed your 1st pipeline.  
+### 5. Making your own pipline
+Now that you have a working example, you can make your own pipeline.  
+You may want to modify the example above, or look at others under `/templates`.
+
+Things are seldom perfect the first time.  Its safe to assume you will want to make iterative changes to your pipeline configuration.  BioLockJ offers some tools to facilitate this process.
+
+ * Check your pipeline using [precheck](Check-Dependencies.md) mode 
+
+ * Add modules onto your partial pipeline using [restart](Failure-Recovery.md)
+
+ * Look through the base set of [modules](Built-in-modules.md) and even [create your own](Building-Modules.md)
+
+A recommended practice is to make a subset of your data, and use that to develope your pipeline. 
+
+### 6. Investigate Failed Pipelines
+Failed pipelines can be restarted to save the progress made by completed modules.
+See [Failure Recovery](../Failure-Recovery) for more information.
+

--- a/mkdocs/user-guide/docs/index.md
+++ b/mkdocs/user-guide/docs/index.md
@@ -24,10 +24,10 @@
      * input files
      * [Dependencies](Dependencies.md)
  * Features
+     * [Check Dependencies](Check-Dependencies.md) before pipeline start
      * [Failure Recovery](Failure-Recovery.md)
      * [Validation](Validation.md)
      * Supported Environments
-     * Check dependencies before pipeline start
      * Expand BioLockJ by [Building Modules](Building-Modules.md)
  * Examples and Templates
      * [Example Pipeline](Example-Pipeline.md)

--- a/mkdocs/user-guide/mkdocs.yml
+++ b/mkdocs/user-guide/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
         - Metadata: The-Metadata-File.md
         - Dependencies: Dependencies.md
     - Features:
+        - Check Dependencies: Check-Dependencies.md
         - Failure Recovery: Failure-Recovery.md
         - Validation: Validation.md
         - Building Modules: Building-Modules.md

--- a/script/blj_functions
+++ b/script/blj_functions
@@ -172,7 +172,8 @@ most_recent_pipeline() {
 }
 
 restartDir_has_status_flag(){
-	ifDefined $restartDir && [ -f $restartDir/biolockjStarted ] || [ -f $restartDir/biolockjFailed ] || [ -f $restartDir/biolockjComplete ]
+	ifDefined $restartDir && [ -f $restartDir/biolockjStarted ] || [ -f $restartDir/biolockjFailed ] || [ -f $restartDir/biolockjComplete ] \
+		|| [ -f $restartDir/precheckStarted ] || [ -f $restartDir/precheckFailed ] || [ -f $restartDir/precheckComplete ] 
 }
 
 

--- a/script/blj_reset
+++ b/script/blj_reset
@@ -11,6 +11,7 @@ main(){
 	set_pipeline_dir
 	set_reset_module
 	
+	possibleStatus=(biolockjComplete biolockjStarted biolockjFailed precheckStarted precheckFailed precheckComplete)
 	reset_modules
 	reset_pipeline_root
 	
@@ -72,19 +73,17 @@ reset_modules(){
 		if ! $(is_empty "$modDir"); then
 			dirName=$(basename "$modDir")
 			if $(is_module_dir "$modDir") && [ $(get_module_number $dirName) -gt $lastCompleted ]; then
+				for statusFlag in ${possibleStatus[@]} ; do
+					local flag="$modDir/$statusFlag"
+					[ -f "$flag" ] && rm "$flag" && echo "Deleted $flag"
+				done
 				touch "$modDir/biolockjFailed" && echo "Created $modDir/biolockjFailed"
-				if [ -f "$modDir/biolockjComplete" ]; then 
-					rm "$modDir/biolockjComplete" && echo "Deleted $modDir/biolockjComplete"
-				elif [ -f "$modDir/biolockjStarted" ]; then
-					rm "$modDir/biolockjStarted" && echo "Deleted $modDir/biolockjStarted"
-				fi
 			fi
 		fi
 	done
 }
 
 reset_pipeline_root(){
-	local possibleStatus=(biolockjComplete biolockjStarted biolockjFailed)
 	for statusFlag in ${possibleStatus[@]} ; do
 		local flag="$pipeDir/$statusFlag"
 		[ -f "$flag" ] && rm "$flag" && echo "Deleted $flag"

--- a/script/blj_user_arg_lib
+++ b/script/blj_user_arg_lib
@@ -31,13 +31,14 @@ set_arg_names(){
 	PROJ_ARG="blj_proj"
 	ENV_ARG="env-var"
 	WAIT_ARG="wait-for-start"
+	PRECHECK="precheck-only"
 }
 
 init_defaults(){
 	# Order does not matter for $longArgName or $takeShortArg, but it is easier to read if they match
 	# Order MATTERS for $shortArgName and $parameters ---they must match whatever order is in $longArgName.
-	longArgName=( $GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $ENV_ARG $WAIT_ARG $PROJ_ARG $EXT_MODS_ARG $BLJ_ARG )
-	takeShortArg=($GUI_ARG $PASSWORD_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $ENV_ARG $WAIT_ARG help version)
+	longArgName=( $GUI_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $ENV_ARG $WAIT_ARG $PRECHECK $PASSWORD_ARG $PROJ_ARG $EXT_MODS_ARG $BLJ_ARG )
+	takeShortArg=($GUI_ARG $CONFIG_ARG $RESTART_ARG $AWS_ARG $DOCKER_ARG $FG_ARG $ENV_ARG $WAIT_ARG $PRECHECK help version)
 	shortArgName=()
 	parameters=()
 	mustTakeValue=($PASSWORD_ARG $CONFIG_ARG $EXT_MODS_ARG $PROJ_ARG $ENV_ARG)
@@ -223,25 +224,37 @@ print_pipeline_status_and_exit(){
 	printf "Fetching pipeline status "
 	local i=0
 	local maxtime=$2
-	while [ $i -lt $maxtime ] || ifArgUsed $WAIT_ARG ; do
+	while [ $i -lt $maxtime ] || ifArgUsed $WAIT_ARG || ifArgUsed $PRECHECK ; do
 		i=$((i+1))
-		if [ -f ${pipeRootDir}/biolockjFailed ]; then 
+		if [ -f ${pipeRootDir}/biolockjFailed ] ; then 
 			echo ""; echo ""
 			echo "BioLockJ has stopped."
 			echo ""
 			cat ${pipeRootDir}/biolockjFailed
 			echo ""; echo ""
 			exit
+		elif [ -f ${pipeRootDir}/precheckFailed ] ; then 
+			echo ""; echo ""
+			echo "There is a problem with this pipeline configuration."
+			echo ""
+			cat ${pipeRootDir}/precheckFailed
+			echo ""; echo ""
+			exit
 		elif [ -f ${pipeRootDir}/biolockjComplete ]; then
 			echo ""; echo ""
 			echo "Pipeline is complete."
+			exit
+		elif [ -f ${pipeRootDir}/precheckComplete ]; then
+			echo ""; echo ""
+			echo "Precheck is complete. No problems were found in this pipeline configuration."
+			echo ""
 			exit
 		elif [ -f ${pipeRootDir}/biolockjStarted ]; then
 			echo ""; echo ""
 			echo "Pipeline is running."
 			exit
 		elif [ $i -eq $maxtime ]; then
-			if ifArgUsed $WAIT_ARG ; then
+			if ifArgUsed $WAIT_ARG || ifArgUsed $PRECHECK ; then
 				printf "(no timeout) "
 			else
 				printf "Reached max wait time: $maxtime seconds. "
@@ -295,7 +308,9 @@ display_help() {
     echo 'Options:'
     addSpace "version"       "Show version"
     addSpace "help"          "Show help menu"
-    addSpace "restart"       "Resume an existing pipeline"
+    addSpace "$PRECHECK"     "Set up pipeline and check dependencies and then STOP;"
+    continueDescriptoin      "do not execute the pipeline. This is helpful when testing edits to config files."
+    addSpace "$RESTART_ARG"  "Resume an existing pipeline"
     addSpace "$CONFIG_ARG <file>" "New config file (if restarting a pipeline)"
     addSpace "$PASSWORD_ARG <password>" "Encrypt password"
     addSpace "$DOCKER_ARG"   "Run in docker"

--- a/script/launch_aws
+++ b/script/launch_aws
@@ -9,6 +9,10 @@ main(){
 	take_standard_biolockj_args "$@"
 	assign_main_arg
 	
+	if ifArgUsed $PRECHECK ; then 
+		exit_with_message "argument \"--$PRECHECK\" is not currently support when running on AWS"
+	fi
+	
 	if ifArgUsed $GUI_ARG ; then
 		exit_after_command run_aws_gui
 	else

--- a/script/launch_docker
+++ b/script/launch_docker
@@ -57,6 +57,7 @@ main(){
 # Read script args and bash env vars
 # Param 1 - Array of launch_docker script args
 scan_script_and_env_args() {
+	ifArgUsed $PRECHECK && ifArgUsed $RESTART_ARG && exit_with_message "Error [ launch_docker ]: \"$PRECHECK\" can only be used with new pipelines; cannot be used in conjunction with \"$RESTART_ARG\". "
 	ifArgUsed $PASSWORD_ARG && newPass=$(get_arg_value $PASSWORD_ARG)
 	ifArgUsed $EXT_MODS_ARG && extMods=$(get_arg_value $EXT_MODS_ARG)
 	ifArgUsed $GUI_ARG && echo "Starting BioLockJ GUI..."
@@ -115,6 +116,7 @@ blj_options() {
 	ifDefined $restartDir && options="${options} -restartDir $restartDir"
 	ifArgUsed $PASSWORD_ARG && options="${options} -password $newPass"
 	ifArgUsed $AWS_ARG && options="${options} -aws"
+	ifArgUsed $PRECHECK && options="${options} -precheck"
 	ifDefined $configFile && options="${options} -config $(to_abs_path ${configFile})"
 	echo "${options}"
 }

--- a/script/launch_java
+++ b/script/launch_java
@@ -41,6 +41,7 @@ check_env_vars(){
 
 check_basic_args(){
 	if ifArgUsed $RESTART_ARG ; then
+		ifArgUsed $PRECHECK && exit_with_message "Error [ launch_java ]: \"$PRECHECK\" can only be used with new pipelines; cannot be used in conjunction with \"$RESTART_ARG\". "
 		[ ! -d $restartDir ] && exit_with_message "Error [ launch_java ]: $restartDir is not a directory on the filesystem."
 		ifArgUsed $CONFIG_ARG && [ ! -f "${configFile}" ] && exit_with_message "Error [ launch_java ]: Config file [ $configFile ] not found on filesystem."
 	else
@@ -73,12 +74,14 @@ assemble_args(){
 	args="-projectDir ${BLJ_PROJ} -homeDir ${HOME}"
 	ifArgUsed $PASSWORD_ARG && args="${args} -password $(get_arg_value $PASSWORD_ARG)" 
 	ifArgUsed $RESTART_ARG && args="${args} -restartDir ${restartDir}"
+	ifArgUsed $PRECHECK && args="${args} -precheck"
 	[ ${#configFile} -gt 0 ] && args="${args} -config ${configFile}"
 	echo $args
 }
 
 before_java_start(){
 	initDir="$(most_recent_pipeline)"
+	[ -f "${initDir}/precheckComplete" ] || [ -f "${initDir}/precheckFailed" ] && replacePrecheckPipe=true
 	pipeDir="${initDir}"
 	initJava=$(ps | grep -c java)
 	numJava=${initJava}
@@ -123,7 +126,7 @@ print_info(){
 		echo "Restarting pipeline:  ${pipeDir}"
 		print_action_options
 		print_pipeline_status_and_exit ${pipeDir} 5
-	elif [ "${initDir}" != "${pipeDir}" ] ; then 
+	elif [ "${initDir}" != "${pipeDir}" ] || [ replacePrecheckPipe ] ; then 
 		echo "Building pipeline:  ${pipeDir}"
 		print_action_options
 		print_pipeline_status_and_exit ${pipeDir} 5

--- a/src/biolockj/Constants.java
+++ b/src/biolockj/Constants.java
@@ -520,6 +520,24 @@ public class Constants {
 	public static final String PIPELINE_NAME = "pipeline.name";
 
 	/**
+	 * Name of the file created in the BioModule root directory to indicate the precheck 
+	 * process encountered an error (if running in precheck mode): {@value #PRECHECK_COMPLETE}
+	 */
+	public static final String PRECHECK_COMPLETE = "precheckComplete";
+	
+	/**
+	 * Name of the file created in the BioModule root directory to indicate the precheck 
+	 * process has completed (if running in precheck mode): {@value #PRECHECK_FAILED}
+	 */
+	public static final String PRECHECK_FAILED = "precheckFailed";
+	
+	/**
+	 * Name of the file created in the BioModule root directory to indicate the precheck 
+	 * process has started (if running in precheck mode): {@value #PRECHECK_STARTED}
+	 */
+	public static final String PRECHECK_STARTED = "precheckStarted";
+	
+	/**
 	 * File suffix appended to processed samples in the module output directory: {@value #PROCESSED}
 	 */
 	public static final String PROCESSED = "_reported" + Constants.TSV_EXT;

--- a/src/biolockj/exception/StopAfterPrecheck.java
+++ b/src/biolockj/exception/StopAfterPrecheck.java
@@ -1,0 +1,24 @@
+package biolockj.exception;
+
+/**
+ * When running in "precheck" mode, this is the mechanism that stops a pipeline from running.
+ * The should ONLY be thrown at the end of the check dependencies phase, and ONLY if the user 
+ * has supplied the precheck runtime parameter.
+ * 
+ * @author Ivory Blakley
+ */
+public class StopAfterPrecheck extends BioLockJException {
+
+	public StopAfterPrecheck( String msg ) {
+		super( msg );
+	}
+	
+	public StopAfterPrecheck( ) {
+		super( myMsg );
+	}
+	
+	private static String myMsg = "This pipeline was configured to stop after checking dependencies.";
+	
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/biolockj/util/BioLockJUtil.java
+++ b/src/biolockj/util/BioLockJUtil.java
@@ -81,7 +81,7 @@ public class BioLockJUtil {
 	}
 
 	public static void clearStatus(String dirPath) {
-		String [] allFlags = {Constants.BLJ_STARTED, Constants.BLJ_FAILED, Constants.BLJ_COMPLETE};
+		String [] allFlags = {Constants.BLJ_STARTED, Constants.BLJ_FAILED, Constants.BLJ_COMPLETE, Constants.PRECHECK_COMPLETE, Constants.PRECHECK_FAILED, Constants.PRECHECK_STARTED};
 		for (String flag : allFlags) {
 			File ff = new File(dirPath + File.separator + flag);
 			if ( ff.exists() ) ff.delete();

--- a/src/biolockj/util/RuntimeParamUtil.java
+++ b/src/biolockj/util/RuntimeParamUtil.java
@@ -204,6 +204,10 @@ public class RuntimeParamUtil {
 	public static boolean isAwsMode() {
 		return params.get( AWS_FLAG ) != null;
 	}
+	
+	public static boolean isPrecheckMode() {
+		return params.get( PRECHECK_FLAG ) != null;
+	}
 
 	/**
 	 * Return TRUE if runtime parameters indicate Logs should be written to system.out
@@ -417,8 +421,13 @@ public class RuntimeParamUtil {
 	 * Log to System.out instead of Log for debug early runtime errors with switch: {@value #SYSTEM_OUT_FLAG}
 	 */
 	protected static final String SYSTEM_OUT_FLAG = "-systemOut";
+	
+	/**
+	 * Flag argument; if present, BioLockJ will stop after checkDependencies step. flag: {@value #SYSTEM_OUT_FLAG}
+	 */
+	protected static final String PRECHECK_FLAG = "-precheck";
 
-	private static final List<String> ARG_FLAGS = Arrays.asList( AWS_FLAG, SYSTEM_OUT_FLAG );
+	private static final List<String> ARG_FLAGS = Arrays.asList( AWS_FLAG, SYSTEM_OUT_FLAG, PRECHECK_FLAG );
 	private static final List<String> DIR_ARGS = Arrays.asList( BLJ_PROJ_DIR, HOME_DIR, RESTART_DIR );
 	private static final List<String> extraParams = new ArrayList<>();
 	private static final List<String> NAMED_ARGS = Arrays.asList( CONFIG_FILE, DIRECT_MODE, HOSTNAME, PASSWORD );


### PR DESCRIPTION
Gives users a way to run check dependencies without running a pipeline.

Feature includes:
 * In precheck mode, a pipeline that would run successfully will stop at the end of check dependencies.
 * IFF the previous precheck pipeline finished (ie, reached precheckComplete or precheckFailed),
   a new pipeline (precheck or not) by the same name will replcae it; thus
   running in precheck mode several times will only produce one folder.
 * In BOTH precheck and standard mode, the precheck flags are applied in the module directories.
 * In ONLY precheck mode, the precheck flags are used at the pipeline top level (this is what makes that pipeline erasable)
 * Any errors found during precheck are presented in the same way they would be shown in standard mode.
 * Precheck is only possible for new pipelines, cannot be used during a restart.
 * The new StopAfterPrecheck exception is the mechanism that stops the pipeline after check dependencies.

Changes include:

 * bash layer components
 * java layer components
 * user-guide updates
 * branch by the same name in sheepdog_testing_suite