### PR TITLE
Relative file paths

### DIFF
--- a/mkdocs/user-guide/docs/Configuration.md
+++ b/mkdocs/user-guide/docs/Configuration.md
@@ -43,7 +43,55 @@ Properties are defined as name-value pairs. List-values are comma separated. Lea
 See the [list of available properties](GENERATED/General-Properties.md).
 
 
-### Special properties
+### Variables
+
+Bash variables can be referenced in the config. They must be "fully dressed": `${VAR}`          
+                    
+There are two variables that BioLockJ requires:            
+`BLJ` is the file path to the BioLockJ direcotry and                
+`BLJ_PROJ` is the directory where pipelines created by BioLockJ are stored and run.            
+After installation these are defined in the shell profile.  These can referenced in the config file.
+
+The `~` ("tilde") is replaced with `${HOME}` if (and only if) the ~ is the *first* character.
+
+Variables can also be defined in the config file and referenced in the same way:
+```text
+DIR=/path/to/big/data/dir                    
+sra.destinationDir=${DIR}/seqs  
+sra.sraAccList=${DIR}/SraAccList.txt      
+input.dirPaths=${DIR}/seqs      
+```
+
+If you are referencing environment variables *and* running in docker, you will need to use the -e parameter to biolockj to pass the variables into the docker environment (even if the variable is defined in the config file). For example:          
+```
+biolockj --docker -e SHEP=$SHEP,DIR=/path/to/big/data/dir config.properties
+```    
+
+### Relative file paths
+
+File paths can be given using relative paths.  The path should start with `./`.         
+The location `.` is interpreted as being the directory where the configuration file is.        
+
+
+Example file structure:
+```
+ /users/joe/analysis01/
+                       config.properties 
+                       metadata.txt
+                       /sra/
+                            SraAccList.txt
+```
+Properties in config.properties can use relative paths:
+```text
+metadata.filePath=./metadata.txt                    
+sra.sraAccList=./sra/SraAccList.txt                   
+``` 
+
+Note: `../` is also supported but it does not stack ( ../../../data/ is not supported). 
+
+With this design, the "analysis01" folder could be shared or moved and the configuration file would not need to be updated to reflect the new location of the project files it references.
+
+## Special properties
 
 Some properties invoke special handling.
 

--- a/script/blj_functions
+++ b/script/blj_functions
@@ -237,7 +237,7 @@ exit_after_command(){
 	local CMD="$@"
 	[ ${#BIOLOCKJ_TEST_MODE} -gt 0 ] && echo "${BIOLOCKJ_TEST_MODE}$CMD" && exit
 	eval $CMD
-	exit
+	exit $?
 }
 
 # If the variable BIOLOCKJ_TEST_MODE exists, the command is shown, not run and the program exits.

--- a/script/blj_user_arg_lib
+++ b/script/blj_user_arg_lib
@@ -166,6 +166,9 @@ export_env_vars(){
 		BLJ_PROJ="${BLJ_PROJ:0:len}"
 	fi
 	export BLJ_PROJ
+	if [ ${#configFile} -gt 0 ]; then
+		cd $(dirname $configFile)
+	fi
 	if ifArgUsed $ENV_ARG ; then
 		envVars=$(get_arg_value $ENV_ARG)
 		vars=${envVars//,/" "}

--- a/script/launch_docker
+++ b/script/launch_docker
@@ -31,7 +31,8 @@ main(){
 	restartDir_has_status_flag && ${BLJ}/script/blj_reset $restartDir
 
 	GUI_PORT=8080
-	CMD="docker run $(docker_args) -e \"BLJ_OPTIONS=$(blj_options)\" $(get_volumes) $(args_for_gui) $(get_docker_img) $(cmd_for_gui)"
+	volumns=$(get_volumes) || exit_with_message "${volumns[@]}"
+	CMD="docker run $(docker_args) -e \"BLJ_OPTIONS=$(blj_options)\" $volumns $(args_for_gui) $(get_docker_img) $(cmd_for_gui)"
 		
 	build_clone_script "${CMD}"
 	
@@ -144,7 +145,9 @@ get_volumes() {
 		else 
 			local i=1
 			readableConfig=$(get_readable_config)
-			configuredDirs=$(${BLJ}/script/read_config.sh $readableConfig "mount")
+			# collec the output of read_config.  IFF that call has a non-0 exit, print any collected error messages.
+			configuredDirs=$(${BLJ}/script/read_config.sh $readableConfig "mount") 
+			[ ! $? -eq 0 ] && echo "${configuredDirs[@]}" && exit 1 #this is called in subshell, failures have to get passed up the chain
 			for dir in ${configuredDirs[@]}; do
 				vols="${vols} -v ${dir}:${EFS}/vol_${i}:ro" 
 				i=$(( i + 1 ))

--- a/script/read_config.sh
+++ b/script/read_config.sh
@@ -67,6 +67,7 @@ read_properties(){
 			for DPROP in ${DPROPS[@]}; do
 				processedVars=$(eval echo "$DPROP") && DPROP=$processedVars
 				dockerCopyPath=$(get_host_file "$DPROP") && DPROP=$dockerCopyPath
+				[ ! -f $DPROP ] && echo "Configured default props file, [$DPROP] is not a file." && exit 1
 				read_properties "$DPROP"
 			done
 		fi

--- a/script/read_config.sh
+++ b/script/read_config.sh
@@ -10,6 +10,7 @@
 # param 2 - one of: upload or mount
 main(){
 	primaryConfig="$1"
+	cd $(dirname $primaryConfig)
 	dirList=($(dirname $(to_abs_path $primaryConfig)))
 	dockerCopyPath=$(get_host_file $primaryConfig) && primaryConfig=$dockerCopyPath
 	
@@ -133,6 +134,10 @@ find_files(){
 	for prop in ${allProps[@]}; do
 		processedVars=$(eval echo "$prop") && prop=$processedVars
 		if possible_file_path $prop; then
+			prop=$(echo ${prop/#..\//`cd ..; pwd`\/})
+			[ $prop == ".." ] && prop=$(`cd ..; pwd`)
+			prop=$(echo ${prop/#.\//`pwd`\/})
+			[ $prop == "." ] && prop=`pwd`
 			if verifyDir $prop; then
 				add_to_dirList $prop
 				add_to_fileList $prop

--- a/src/biolockj/Config.java
+++ b/src/biolockj/Config.java
@@ -398,8 +398,9 @@ public class Config {
 	public static void initialize() throws Exception {
 		configFile = RuntimeParamUtil.getConfigFile();
 		Log.info( Config.class, "Initialize Config: " + configFile.getAbsolutePath() );
-		props = replaceEnvVars( Properties.loadProperties( configFile ) );
 		setPipelineRootDir();
+		props = replaceEnvVars( Properties.loadProperties( configFile ) );
+		setFilePathProperty( Constants.INTERNAL_PIPELINE_DIR, pipelineDir.getAbsolutePath() );
 		if( !BioLockJUtil.isDirectMode() && !FileUtils.directoryContains( getPipelineDir(), configFile ) )
 			FileUtils.copyFileToDirectory( configFile, getPipelineDir() );
 		Log.info( Config.class, "Total # initial properties: " + props.size() );
@@ -734,7 +735,8 @@ public class Config {
 	 * @throws DockerVolCreationException 
 	 */
 	public static void setPipelineDir( final File dir ) throws DockerVolCreationException {
-		setFilePathProperty( Constants.INTERNAL_PIPELINE_DIR, dir.getAbsolutePath() );
+		// Set this after the props are initialized. Dir is formed FIRST in case of errors while initializing props.
+		//setFilePathProperty( Constants.INTERNAL_PIPELINE_DIR, dir.getAbsolutePath() );
 		pipelineDir = dir;
 		String printPathOnScreen = DockerUtil.inDockerEnv() ? DockerUtil.deContainerizePath( pipelineDir.getAbsolutePath() ) : pipelineDir.getAbsolutePath();
 		System.out.println( Constants.PIPELINE_LOCATION_KEY + printPathOnScreen);

--- a/src/biolockj/util/ValidationUtil.java
+++ b/src/biolockj/util/ValidationUtil.java
@@ -343,16 +343,12 @@ public class ValidationUtil {
 	}
 
 	private static File getExpectationFile( final BioModule module ) throws ConfigException, DockerVolCreationException {
+		File expectationFileObj = Config.getExistingFileObject( Config.getString( module, EXPECTATION_FILE ) );
 		File expectationFile = null;
-		String expectationFilePath = Config.getString( module, EXPECTATION_FILE );
-		if( expectationFilePath != null && !expectationFilePath.isEmpty() ) {
-			if ( DockerUtil.inDockerEnv() ) expectationFilePath = DockerUtil.containerizePath( expectationFilePath );
-			expectationFile = new File( expectationFilePath );
-			if( !expectationFile.exists() ) throw new ConfigPathException( expectationFile );
-			System.out.println("expectation file path: " + expectationFilePath );
-			if( expectationFile.isDirectory() ) {
-				expectationFile = new File(
-					expectationFilePath + File.separator + getOutputFileName( module ) );
+		if( expectationFileObj != null ) {
+			if( !expectationFileObj.exists() ) throw new ConfigPathException( expectationFileObj );
+			if( expectationFileObj.isDirectory() ) {
+				expectationFile = new File( expectationFileObj, getOutputFileName( module ) );
 				if( !expectationFile.exists() )
 					throw new ConfigPathException( expectationFile, "Could not find file: " +
 						getOutputFileName( module ) + " in directory " + Config.getString( module, EXPECTATION_FILE ) );


### PR DESCRIPTION
Allow file paths in the config file to use ./ to reference the directory that the config file is in.